### PR TITLE
remove 'X' from event tabs

### DIFF
--- a/src/components/rower/RowerImage.vue
+++ b/src/components/rower/RowerImage.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        {{ n }}x
+        {{ n }}
         <b-img class="card-img-header" src="https://images.poweredbyiris.nl/boats/rower.png"></b-img>
     </div>
 </template>


### PR DESCRIPTION
because the x often causes confusion among users I removed it. in the future we will have to look at making the event tabs stand out more.