### PR TITLE
Adds custom SCSS file and moves import location for bootstrap

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,24 +5,8 @@
 </template>
 
 <style lang="scss">
-.ploeg {
-    max-width: 150px;
-}
-@media (max-width: 400px) {
-    .table-responsive {
-        font-size: 10px !important;
-    }
-}
-@media (max-width: 350px) {
-    .ploeg {
-        max-width: 80px;
-        overflow-x: hidden;
-    }
-}
-.clickable {
-    cursor: pointer;
-}
-.nav-link strong {
-    text-decoration: underline;
-}
+@import 'assets/custom.scss';
+
+@import '~bootstrap/scss/bootstrap.scss';
+@import '~bootstrap-vue/src/index.scss';
 </style>

--- a/src/Views/VenuesOverview.vue
+++ b/src/Views/VenuesOverview.vue
@@ -1,15 +1,15 @@
 <template>
     <div>
         <FrontpageNavBar> </FrontpageNavBar>
-        <div class="container">
+        <div class="container mt-5">
             <h2>Recente Wedstrijden</h2>
-            <b-card-group deck class="venueDeck justify-content-center">
+            <b-card-group deck class="venueDeck">
                 <b-card
                     v-for="regatta in recentRegattas"
                     :key="regatta.shortname"
-                    bg-variant="secondary"
+                    bg-variant="black"
                     text-variant="white"
-                    class="text-center"
+                    class="text-center clickable ml-1"
                     v-on:click="openEdition(regatta)"
                 >
                     <b-card-text>{{ regatta.regattaname }}</b-card-text>
@@ -17,13 +17,13 @@
             </b-card-group>
             <br />
             <h2>Archief</h2>
-            <b-card-group deck class="venueDeck justify-content-center">
+            <b-card-group deck class="venueDeck">
                 <b-card
                     v-for="regatta in regattasList"
                     :key="regatta.shortname"
-                    bg-variant="secondary"
+                    bg-variant="black"
                     text-variant="white"
-                    class="text-center"
+                    class="text-center clickable ml-1"
                     v-on:click="openEdition(regatta)"
                 >
                     <b-card-text>{{ regatta.regattaname }}</b-card-text>
@@ -35,10 +35,10 @@
 
 <script>
 import FrontpageNavBar from '@/components/Navigation/FrontpageNavBar';
-import { Service } from '../Services/Service';
+import { Service } from '@/Services/Service';
 import { sendPageView } from './analytics';
 import uniqBy from '../Helpers/uniqBy';
-import { openRegatta } from '../Helpers/Routing';
+import { openRegatta } from '@/Helpers/Routing';
 
 export default {
     name: 'VenuesOverview',
@@ -90,14 +90,14 @@ export default {
 };
 </script>
 
-<style type="scss" scoped>
+<style scoped>
 .venueDeck {
     flex-wrap: wrap !important;
     flex-grow: 1 !important;
 }
 
 .venueDeck * {
-    flex-basis: 18% !important;
+    flex-basis: 30% !important;
     margin: 15px 0 15px;
 }
 

--- a/src/assets/custom.scss
+++ b/src/assets/custom.scss
@@ -1,0 +1,42 @@
+@import url("https://fonts.googleapis.com/css?family=Montserrat");
+@import url("https://fonts.googleapis.com/css?family=Roboto");
+
+$black: #000 !default;
+
+$theme-colors: () !default;
+$theme-colors: map-merge(
+                (
+                        'black': $black,
+                ),
+                $theme-colors
+);
+
+body {
+  font-family: Montserrat, sans-serif !important;
+}
+
+.ploeg {
+  max-width: 150px;
+}
+
+@media (max-width: 400px) {
+  .table-responsive {
+    font-size: 10px !important;
+  }
+}
+
+@media (max-width: 350px) {
+  .ploeg {
+    max-width: 80px;
+    overflow-x: hidden;
+  }
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.nav-link strong {
+  text-decoration: underline;
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,6 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
 import BootstrapVue from 'bootstrap-vue';
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap-vue/dist/bootstrap-vue.css';
 
 Vue.use(BootstrapVue);
 Vue.config.productionTip = false;


### PR DESCRIPTION
Moves loading of bootstrap style files to App.vue as well as loading the scss as opposed to compiled css files. Move allows for adding of custom styles (global) in custom.css (location/naming might not be ideal yet?).

Adds clickable class to venue elements, improving visual awareness that item is actually a link.

Adds a new theme variant color 'black' allowing it to be used as background color.

Changes font-family to Montserrat for viewing pleasure.

Ensures all venues texts are vertically aligned by giving the element some more space 18% -> 30%. Vertical alignment was broken by split-line texts.

Before:
![image](https://user-images.githubusercontent.com/4410453/112910016-c8c87d80-90f2-11eb-8dc4-2f279c7b6d8e.png)


After:
![image](https://user-images.githubusercontent.com/4410453/112909987-bd755200-90f2-11eb-8199-cb170643b8a6.png)

